### PR TITLE
Fix failing decode of credentials

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -90,8 +90,8 @@ func DecodeBase64Auth(auth AuthConfig) (string, string, error) {
 		return "", "", fmt.Errorf("error decoding auth from file: %w", err)
 	}
 
-	if n != decLen {
-		return "", "", fmt.Errorf("decoded value does not match expected length, expected: %d, actual: %d", decLen, n)
+	if n > decLen {
+		return "", "", fmt.Errorf("decoded value is longer than expected length, expected: %d, actual: %d", decLen, n)
 	}
 
 	split := strings.SplitN(string(decoded), ":", 2)


### PR DESCRIPTION
We experienced an issue where this library failed to read some credentials. The credentials are set via `docker login`.

The check that compares the number of written bytes with the maximum length in bytes is too restrictive.
The Docker CLI implements the check a bit differently ([link to source](https://github.com/docker/cli/blob/a32cd16160f1b41c1c4ae7bee4dac929d1484e59/cli/config/configfile/file.go#L292-L294)).

This change aligns the check with what the Docker CLI is doing.