### PR TITLE
chore: improve errors

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,39 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  GO_VERSION: "1.23"
+  GOLANGCI_VERSION: "v1.59.1"
+
+jobs:
+  lint-test-go:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Validate go mod tidy
+        run: |
+          go mod tidy
+          git --no-pager diff && [[ 0 -eq $(git status --porcelain | wc -l) ]]
+
+      - name: Go Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: ${{ env.GOLANGCI_VERSION }}
+          args: --out-format=colored-line-number
+
+      - name: Test
+        run: go test -race ./...

--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	DetachKeys           string                 `json:"detachKeys,omitempty"`
 	CredentialsStore     string                 `json:"credsStore,omitempty"`
 	CredentialHelpers    map[string]string      `json:"credHelpers,omitempty"`
-	Filename             string                 `json:"-"` // Note: for internal use only
+	Filename             string                 `json:"-"` // Note: for internal use only.
 	ServiceInspectFormat string                 `json:"serviceInspectFormat,omitempty"`
 	ServicesFormat       string                 `json:"servicesFormat,omitempty"`
 	TasksFormat          string                 `json:"tasksFormat,omitempty"`
@@ -30,7 +30,7 @@ type Config struct {
 	Aliases              map[string]string      `json:"aliases,omitempty"`
 }
 
-// ProxyConfig contains proxy configuration settings
+// ProxyConfig contains proxy configuration settings.
 type ProxyConfig struct {
 	HTTPProxy  string `json:"httpProxy,omitempty"`
 	HTTPSProxy string `json:"httpsProxy,omitempty"`
@@ -38,7 +38,7 @@ type ProxyConfig struct {
 	FTPProxy   string `json:"ftpProxy,omitempty"`
 }
 
-// AuthConfig contains authorization information for connecting to a Registry
+// AuthConfig contains authorization information for connecting to a Registry.
 type AuthConfig struct {
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
@@ -55,11 +55,11 @@ type AuthConfig struct {
 	// an access token for the registry.
 	IdentityToken string `json:"identitytoken,omitempty"`
 
-	// RegistryToken is a bearer token to be sent to a registry
+	// RegistryToken is a bearer token to be sent to a registry.
 	RegistryToken string `json:"registrytoken,omitempty"`
 }
 
-// KubernetesConfig contains Kubernetes orchestrator settings
+// KubernetesConfig contains Kubernetes orchestrator settings.
 type KubernetesConfig struct {
 	AllNamespaces string `json:"allNamespaces,omitempty"`
 }

--- a/load.go
+++ b/load.go
@@ -11,7 +11,7 @@ import (
 func UserHomeConfigPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("error looking up user home dir: %w", err)
+		return "", fmt.Errorf("user home dir: %w", err)
 	}
 
 	return filepath.Join(home, ".docker", "config.json"), nil
@@ -19,7 +19,7 @@ func UserHomeConfigPath() (string, error) {
 
 // ConfigPath returns the path to the docker cli config.
 //
-// It will either use the DOCKER_CONFIG env var if set, or the value from `UserHomeConfigPath`
+// It will either use the DOCKER_CONFIG env var if set, or the value from [UserHomeConfigPath]
 // DOCKER_CONFIG would be the dir path where `config.json` is stored, this returns the path to config.json.
 func ConfigPath() (string, error) {
 	if p := os.Getenv("DOCKER_CONFIG"); p != "" {
@@ -28,24 +28,28 @@ func ConfigPath() (string, error) {
 	return UserHomeConfigPath()
 }
 
-// LoadDefaultConfig loads the docker cli config from the path returned from `ConfigPath`
+// LoadDefaultConfig loads the docker cli config from the path returned from [ConfigPath].
 func LoadDefaultConfig() (Config, error) {
 	var cfg Config
 	p, err := ConfigPath()
 	if err != nil {
-		return cfg, err
+		return cfg, fmt.Errorf("config path: %w", err)
 	}
+
 	return cfg, FromFile(p, &cfg)
 }
 
-// FromFile loads config from the specified path into cfg
+// FromFile loads config from the specified path into cfg.
 func FromFile(configPath string, cfg *Config) error {
 	f, err := os.Open(configPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("open config: %w", err)
+	}
+	defer f.Close()
+
+	if err = json.NewDecoder(f).Decode(&cfg); err != nil {
+		return fmt.Errorf("decode config: %w", err)
 	}
 
-	err = json.NewDecoder(f).Decode(&cfg)
-	f.Close()
-	return err
+	return nil
 }

--- a/testdata/config.json
+++ b/testdata/config.json
@@ -1,0 +1,17 @@
+{
+	"auths": {
+		"userpass.io": {
+			"username": "user",
+			"password": "pass"
+		},
+		"auth.io": {
+			"auth": "YXV0aDphdXRoc2VjcmV0"
+		}
+	},
+	"credHelpers": {
+		"helper.io": "helper",
+		"other.io": "other",
+		"error.io": "error"
+	},
+	"credsStore": "desktop"
+  }


### PR DESCRIPTION
Improve the reported errors so that consumers can understand why failure occurs.

This is vital for credential lookup failures, which is impossible to debug otherwise, for example permission error when using gcloud as credentials helper as identified debugging an issue in testcontainers.

Eliminate wrapping errors with "error ..." as that results in messages which are hard to understand in a multi wrap.

Add tests to cover credentials helper, ensuring that command handling behaves correctly.

Modernise error checks to use errors.Is.

Leverage doc comment reference linking instead of backticks.

Use Auth fallback if credentials store reports not found.

Remove impossible decode length check and ensure decoded data is sized correctly, eliminating need for \x00 trim.

Add github action to run test and lint.
    
Fix from base64 auth tests not running due to missing parameter.
    
Fix some comment typos.